### PR TITLE
Add Location header to POST /recipes

### DIFF
--- a/api/gateway/routes/recipes/controller.py
+++ b/api/gateway/routes/recipes/controller.py
@@ -96,7 +96,8 @@ class Controller(litestar.Controller):
             result = await client.recipes.create(data)
         return Response(
             schemas.Recipe.create(result.recipe, result.translation),
-            headers=Header.last_modified(result.modified),
+            headers=Header.last_modified(result.modified)
+            | Header.location(f"/api/recipes/{result.recipe.id}"),
         )
 
     @litestar.put(


### PR DESCRIPTION
Implements issue #17.
This PR adds a Location header to the POST /recipes endpoint, indicating the URI of the newly created recipe.

